### PR TITLE
chore: remove commit_status_404s attribute

### DIFF
--- a/buildkite/provider/resource_pipeline.go
+++ b/buildkite/provider/resource_pipeline.go
@@ -244,10 +244,6 @@ var (
 						Type:     schema.TypeBool,
 						Optional: true,
 					},
-					"commit_status_404s": {
-						Type:     schema.TypeInt,
-						Optional: true,
-					},
 					"filter_enabled": {
 						Type:     schema.TypeBool,
 						Optional: true,

--- a/website/docs/r/pipeline.md
+++ b/website/docs/r/pipeline.md
@@ -132,8 +132,6 @@ For more information about steps, take a look at the [official documentation](ht
 
 * `separate_pull_request_statuses` - (Optional) Publish separate status for the pull request itself.
 
-* `commit_status_404s` - (Optional)
-
 
 ## Attributes Reference
 


### PR DESCRIPTION
This value is read-only, and can not be modified via the API