### PR TITLE
fix: mark sensitive fields to prevent log/state exposure [JAINFRA-234]

### DIFF
--- a/buildkite/provider/provider.go
+++ b/buildkite/provider/provider.go
@@ -37,6 +37,7 @@ func Provider() *schema.Provider {
 			"api_token": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
+				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("BUILDKITE_API_TOKEN", nil),
 			},
 		},

--- a/buildkite/provider/resource_pipeline.go
+++ b/buildkite/provider/resource_pipeline.go
@@ -66,8 +66,9 @@ var (
 			},
 		},
 		"webhook_url": {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:      schema.TypeString,
+			Computed:  true,
+			Sensitive: true,
 		},
 		"configuration": {
 			Type:          schema.TypeString,


### PR DESCRIPTION
## Summary

- **AISAST-8538:** Add `Sensitive: true` to the `api_token` provider schema field — prevents the Buildkite API token from appearing in debug/crash logs
- **AISAST-8537:** Add `Sensitive: true` to the `webhook_url` computed field — prevents the capability-bearing webhook URL from appearing in plan/show output and state dumps

## Context

Without `Sensitive: true`, the terraform-plugin-sdk treats these values as ordinary configuration/computed data and includes them in `TF_LOG=DEBUG` output, crash logs, `terraform show`, and `terraform state pull`. The API token grants full org control; the webhook URL is capability-bearing (the token in the path is the only auth for inbound SCM events).

## Test plan

- [ ] Run `TF_LOG=DEBUG terraform plan` and confirm api_token is redacted as `(sensitive value)`
- [ ] Run `terraform show` after apply and confirm webhook_url is redacted
- [ ] Verify `terraform providers schema -json` does not expose the token

🤖 Generated with [Claude Code](https://claude.com/claude-code)